### PR TITLE
HACK: pin pandas

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - scikit-bio
     - numpy
     - statsmodels  # TODO: fix this upstream
-    - pandas
+    - pandas 0.20.3
     - seaborn
     - bokeh
     - biom-format >=2.1.5,<2.2.0


### PR DESCRIPTION
It looks like something has changed with the dtype handling in pandas 0.21.0 which is causing dataframes of `float64` to become `object`. Numpy then broadcasts the object dtype which in turn become the backing array for other pandas objects which now have the `object` dtype and fail gneiss's sanity checking.