### PR TITLE
MAINT: update dtype coercion for new pandas API

### DIFF
--- a/q2_gneiss/cluster/_cluster.py
+++ b/q2_gneiss/cluster/_cluster.py
@@ -83,7 +83,7 @@ def gradient_clustering(table: pd.DataFrame,
     c = gradient.to_series()
     c = c.astype(np.float)
     if not weighted:
-        table = table > 0
+        table = (table > 0).astype(np.float)
     table, c = match(table, c)
     t = gradient_linkage(table, c, method='average')
     mean_g = mean_niche_estimator(table, c)


### PR DESCRIPTION
Previously a boolean dataframe would have been coerced into float64. But
now the dtype is more "preserved" and becomes object when broadcast with
a float64 vector.

This just updates gradient_clustering to coerce the dtype to float64 so
that the dtype after broadcasting remains float64.