### PR TITLE
Making the FeatureTable[Composition] optional in ilr transform

### DIFF
--- a/q2_gneiss/composition/_composition.py
+++ b/q2_gneiss/composition/_composition.py
@@ -7,14 +7,14 @@
 # ----------------------------------------------------------------------------
 from q2_types.tree import Hierarchy, Phylogeny, Rooted
 from q2_gneiss.plugin_setup import plugin
-from q2_types.feature_table import FeatureTable, Frequency, Balance
+from q2_types.feature_table import FeatureTable, Frequency, Balance, Composition
 from q2_gneiss.composition._method import ilr_hierarchical, ilr_phylogenetic
 from qiime2.plugin import Float
 
 
 plugin.methods.register_function(
     function=ilr_hierarchical,
-    inputs={'table': FeatureTable[Frequency],
+    inputs={'table': FeatureTable[Frequency | Composition],
             'tree': Hierarchy},
     outputs=[('balances', FeatureTable[Balance])],
     parameters={'pseudocount': Float},
@@ -41,7 +41,7 @@ plugin.methods.register_function(
 
 plugin.methods.register_function(
     function=ilr_phylogenetic,
-    inputs={'table': FeatureTable[Frequency],
+    inputs={'table': FeatureTable[Frequency | Composition],
             'tree': Phylogeny[Rooted]},
     outputs=[('balances', FeatureTable[Balance]),
              ('hierarchy', Hierarchy)],

--- a/q2_gneiss/composition/_composition.py
+++ b/q2_gneiss/composition/_composition.py
@@ -7,7 +7,8 @@
 # ----------------------------------------------------------------------------
 from q2_types.tree import Hierarchy, Phylogeny, Rooted
 from q2_gneiss.plugin_setup import plugin
-from q2_types.feature_table import FeatureTable, Frequency, Balance, Composition
+from q2_types.feature_table import (FeatureTable, Frequency, 
+                                    Balance, Composition)
 from q2_gneiss.composition._method import ilr_hierarchical, ilr_phylogenetic
 from qiime2.plugin import Float
 

--- a/q2_gneiss/composition/_composition.py
+++ b/q2_gneiss/composition/_composition.py
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 from q2_types.tree import Hierarchy, Phylogeny, Rooted
 from q2_gneiss.plugin_setup import plugin
-from q2_types.feature_table import (FeatureTable, Frequency, 
+from q2_types.feature_table import (FeatureTable, Frequency,
                                     Balance, Composition)
 from q2_gneiss.composition._method import ilr_hierarchical, ilr_phylogenetic
 from qiime2.plugin import Float


### PR DESCRIPTION
This came out of a discussion with @ebolyen 

There are two reasons why we will want this

1. There are still use cases for utilizing the composition type (we have another plugin coming on board that will output these types).  Allowing the ilr transform accept composition types will be very helpful
2. To ensure backwards compatiability