### PR TITLE
BUG: Improve error message raised in #59

### DIFF
--- a/q2_gneiss/plot/_plot.py
+++ b/q2_gneiss/plot/_plot.py
@@ -140,14 +140,13 @@ def balance_taxonomy(output_dir: str, table: pd.DataFrame, tree: TreeNode,
             except ValueError:
                 pass
             else:
-                raise ValueError('Your categorical metadata column '
+                raise ValueError('Categorical metadata column '
                                  f'{metadata.name!r} contains only numerical '
-                                 'categories. Note: At least one category '
-                                 'must be non-numerical.')
+                                 'values. At least one value must be '
+                                 'non-numerical.')
 
             balance_boxplot(balance_name, data, y=c.name, ax=ax,
                             palette=sample_palette)
-
             if len(c.value_counts()) > 2:
                 warnings.warn(
                     'More than 2 categories detected in categorical metadata '

--- a/q2_gneiss/plot/_plot.py
+++ b/q2_gneiss/plot/_plot.py
@@ -134,28 +134,29 @@ def balance_taxonomy(output_dir: str, table: pd.DataFrame, tree: TreeNode,
             sample_palette = pd.Series(
                 sns.color_palette("Set2", len(c.value_counts())),
                 index=c.value_counts().index)
-            try:
-                balance_boxplot(balance_name, data, y=c.name, ax=ax,
-                                palette=sample_palette)
-            except TypeError as e:
-                if 'flexible type' in str(e):
-                    def is_float(category):
-                        try:
-                            float(category)
-                            return True
-                        except ValueError:
-                            return False
-                    categories = data[metadata.name]
-                    inv_categories = list(set(category for category
-                                          in categories if is_float(category)))
-                    inv_categories.sort()
-                    raise ValueError('Your categorical metadata column '
-                                     f'{metadata.name!r} contains the '
-                                     'following invalid categories '
-                                     f'{inv_categories!r}. Note: numerical '
-                                     'categories are not supported.') from e
-                else:
-                    raise e
+
+            def is_float(category):
+                try:
+                    float(category)
+                    return True
+                except ValueError:
+                    return False
+
+            categories = data[metadata.name]
+            inv_categories = [category for category in categories if
+                              is_float(category)]
+            if len(inv_categories) == len(categories):
+                inv_categories = list(set(inv_categories))
+                inv_categories.sort()
+                raise ValueError('Your categorical metadata column '
+                                 f'{metadata.name!r} contains the '
+                                 'following invalid categories '
+                                 f'{inv_categories!r}. Note: At least one '
+                                 'category must be non-numerical.')
+
+            balance_boxplot(balance_name, data, y=c.name, ax=ax,
+                            palette=sample_palette)
+
             if len(c.value_counts()) > 2:
                 warnings.warn(
                     'More than 2 categories detected in categorical metadata '

--- a/q2_gneiss/plot/_plot.py
+++ b/q2_gneiss/plot/_plot.py
@@ -135,24 +135,15 @@ def balance_taxonomy(output_dir: str, table: pd.DataFrame, tree: TreeNode,
                 sns.color_palette("Set2", len(c.value_counts())),
                 index=c.value_counts().index)
 
-            def is_float(category):
-                try:
-                    float(category)
-                    return True
-                except ValueError:
-                    return False
-
-            categories = data[metadata.name]
-            inv_categories = [category for category in categories if
-                              is_float(category)]
-            if len(inv_categories) == len(categories):
-                inv_categories = list(set(inv_categories))
-                inv_categories.sort()
+            try:
+                pd.to_numeric(metadata.to_series())
+            except ValueError:
+                pass
+            else:
                 raise ValueError('Your categorical metadata column '
-                                 f'{metadata.name!r} contains the '
-                                 'following invalid categories '
-                                 f'{inv_categories!r}. Note: At least one '
-                                 'category must be non-numerical.')
+                                 f'{metadata.name!r} contains only numerical '
+                                 'categories. Note: At least one category '
+                                 'must be non-numerical.')
 
             balance_boxplot(balance_name, data, y=c.name, ax=ax,
                             palette=sample_palette)

--- a/q2_gneiss/plot/_plot.py
+++ b/q2_gneiss/plot/_plot.py
@@ -134,8 +134,28 @@ def balance_taxonomy(output_dir: str, table: pd.DataFrame, tree: TreeNode,
             sample_palette = pd.Series(
                 sns.color_palette("Set2", len(c.value_counts())),
                 index=c.value_counts().index)
-            balance_boxplot(balance_name, data, y=c.name, ax=ax,
-                            palette=sample_palette)
+            try:
+                balance_boxplot(balance_name, data, y=c.name, ax=ax,
+                                palette=sample_palette)
+            except TypeError as e:
+                if 'flexible type' in str(e):
+                    def is_float(category):
+                        try:
+                            float(category)
+                            return True
+                        except ValueError:
+                            return False
+                    categories = data[metadata.name]
+                    inv_categories = list(set(category for category
+                                          in categories if is_float(category)))
+                    inv_categories.sort()
+                    raise ValueError('Your categorical metadata column '
+                                     f'{metadata.name!r} contains the '
+                                     'following invalid categories '
+                                     f'{inv_categories!r}. Note: numerical '
+                                     'categories are not supported.') from e
+                else:
+                    raise e
             if len(c.value_counts()) > 2:
                 warnings.warn(
                     'More than 2 categories detected in categorical metadata '

--- a/q2_gneiss/plot/tests/test_plot.py
+++ b/q2_gneiss/plot/tests/test_plot.py
@@ -348,7 +348,6 @@ class TestBalanceTaxonomy(unittest.TestCase):
                          self.taxonomy, balance_name='a',
                          metadata=self.partial_numerical_categorical)
 
-        self.assertTrue(os.path.exists(index_fp))
         for file in ['numerator.csv', 'denominator.csv',
                      'balance_metadata.pdf']:
             self.assertTrue(os.path.exists(os.path.join(self.results, file)))

--- a/q2_gneiss/plot/tests/test_plot.py
+++ b/q2_gneiss/plot/tests/test_plot.py
@@ -347,32 +347,23 @@ class TestBalanceTaxonomy(unittest.TestCase):
         balance_taxonomy(self.results, self.table, self.tree,
                          self.taxonomy, balance_name='a',
                          metadata=self.partial_numerical_categorical)
-        self.assertTrue(os.path.exists(index_fp))
-        # test to make sure that the numerator file is there
-        num_fp = os.path.join(self.results, 'numerator.csv')
-        self.assertTrue(os.path.exists(num_fp))
-        # test to make sure that the denominator file is there
-        denom_fp = os.path.join(self.results, 'denominator.csv')
-        self.assertTrue(os.path.exists(denom_fp))
-        box_fp = os.path.join(self.results, 'balance_metadata.pdf')
-        self.assertTrue(os.path.exists(box_fp))
-        prop_fp = os.path.join(self.results, 'proportion_plot.pdf')
-        self.assertFalse(os.path.exists(prop_fp))
 
-        box_fp = os.path.join(self.results, 'balance_metadata.pdf')
-        self.assertTrue(os.path.exists(box_fp))
-        prop_fp = os.path.join(self.results, 'proportion_plot.pdf')
-        self.assertFalse(os.path.exists(prop_fp))
+        self.assertTrue(os.path.exists(index_fp))
+        for file in ['numerator.csv', 'denominator.csv',
+                     'balance_metadata.pdf']:
+            self.assertTrue(os.path.exists(os.path.join(self.results, file)))
+        self.assertFalse(os.path.exists(os.path.join(self.results,
+                                                     'proportion_plot.pdf')))
 
         with open(index_fp, 'r') as fh:
             html = fh.read()
-            self.assertIn('<h1>Balance Taxonomy</h1>', html)
-            self.assertIn('Numerator taxa', html)
-            self.assertIn('Denominator taxa', html)
+            for exp in ['<h1>Balance Taxonomy</h1>', 'Numerator taxa',
+                        'Denominator taxa']:
+                self.assertIn(exp, html)
             self.assertNotIn('Proportion', html)
 
     def test_balance_taxonomy_full_numerical_categorical(self):
-        with self.assertRaisesRegex(ValueError, 'only numerical categories'):
+        with self.assertRaisesRegex(ValueError, 'only numerical values'):
             balance_taxonomy(self.results, self.table, self.tree,
                              self.taxonomy, balance_name='a',
                              metadata=self.full_numerical_categorical)

--- a/q2_gneiss/plot/tests/test_plot.py
+++ b/q2_gneiss/plot/tests/test_plot.py
@@ -372,8 +372,7 @@ class TestBalanceTaxonomy(unittest.TestCase):
             self.assertNotIn('Proportion', html)
 
     def test_balance_taxonomy_full_numerical_categorical(self):
-        with self.assertRaisesRegex(ValueError, r".*categorical.*'1', '1.0', "
-                                                "'2', '2.0', '3'"):
+        with self.assertRaisesRegex(ValueError, 'only numerical categories'):
             balance_taxonomy(self.results, self.table, self.tree,
                              self.taxonomy, balance_name='a',
                              metadata=self.full_numerical_categorical)

--- a/q2_gneiss/plot/tests/test_plot.py
+++ b/q2_gneiss/plot/tests/test_plot.py
@@ -209,6 +209,9 @@ class TestBalanceTaxonomy(unittest.TestCase):
         self.multi_categorical = CategoricalMetadataColumn(
             pd.Series(['a', 'a', 'c', 'b', 'b', 'b', 'c'],
                       index=index, name='multi_categorical'))
+        self.numerical_categorical = CategoricalMetadataColumn(
+            pd.Series(['1', '1', '1.0', '2', '2', '2', '2.0'],
+                      index=index, name='numerical_categorical'))
         self.continuous = NumericMetadataColumn(
             pd.Series(np.arange(7), index=index, name='continuous'))
 
@@ -335,6 +338,13 @@ class TestBalanceTaxonomy(unittest.TestCase):
             self.assertIn('Numerator taxa', html)
             self.assertIn('Denominator taxa', html)
             self.assertNotIn('Proportion', html)
+
+    def test_balance_taxonomy_numerical_categorical(self):
+        with self.assertRaisesRegex(ValueError, r".*categorical.*'1', '1.0', "
+                                    "'2', '2.0'"):
+            balance_taxonomy(self.results, self.table, self.tree,
+                             self.taxonomy, balance_name='a',
+                             metadata=self.numerical_categorical)
 
     def test_balance_taxonomy_continuous(self):
         index_fp = os.path.join(self.results, 'index.html')


### PR DESCRIPTION
Upon further inspection, the error raised in #59 originates deep down in 3rd party dependencies, and will probably need to be addressed in those dependencies by the people maintaining them. As such, all I've done here is improve the error message produced, and create a test to verify it works properly. The new error message, produced with the data and command referenced in [this](https://forum.qiime2.org/t/plugin-error-from-gneiss-cannot-perform-reduce-with-flexible-type/8717) forum thread in which this bug was initially brought to our attention, looks like this right now:

![new_error](https://user-images.githubusercontent.com/10642616/58591163-8003bd00-821a-11e9-9b40-a0d6a8c5d305.png)

and should hopefully prove more informative for users who receive it. My best, relatively uneducated, guess as to what is actually happening is when matplotlib's Cython functions are invoked, they don't know whether a category like '1' should be turned into the integer 1 or the char/cstring '1'/"1" causing the "flexible type" error. I tried a couple of things to remedy this and tested them with the same data and commands referenced above. First, simply catching the error and throwing it away unsurprisingly didn't work and resulted in an empty boxplot, though the rest of the plots were still accurate. Second, explicitly casting the categories from string to a numerical value (int or float, both behaved the same in my tests) before passing them to `balance_boxplot()` via something like this:

![conversion](https://user-images.githubusercontent.com/10642616/58590933-08359280-821a-11e9-8d91-5db07179346d.png)

resulted in an utter garbage boxplot:

![garbage_plot](https://user-images.githubusercontent.com/10642616/58590957-18e60880-821a-11e9-8e12-d68f691ecd53.png)

Several other things were attempted including the rather hacky appending of ' ' to the end of every numerical category in the hopes of this convincing Cython to turn them unambiguously into strings, but this unsurprisingly failed. Appending non-whitespace characters did work of course, but that noticeably changes the name of the column, still, this is an option. If anyone else has any ideas for how to actually solve this problem great, otherwise the new error message is the best I could do.