### PR TITLE
BUG: Raise exception when samples in table not present in metadata

### DIFF
--- a/q2_gneiss/cluster/tests/test_cluster.py
+++ b/q2_gneiss/cluster/tests/test_cluster.py
@@ -81,6 +81,24 @@ class TestClusteringPlugin(unittest.TestCase):
 
         self.assertNotEqual(str(res_clust_uw), str(res_clust_w))
 
+    def test_gradient_missing_samples(self):
+        from qiime2.plugins.gneiss.methods import gradient_clustering
+        table = pd.DataFrame({"x": 1, "y": 2}, index=["a", "s1"])
+        table = qiime2.Artifact.import_data("FeatureTable[Frequency]", table)
+        metadata = qiime2.Metadata.load(get_data_path("test_metadata.txt"))
+
+        with self.assertRaisesRegex(KeyError, "not present.*a"):
+            gradient_clustering(table, metadata.get_column("x"))
+
+    def test_gradient_ignore_missing_samples(self):
+        from qiime2.plugins.gneiss.methods import gradient_clustering
+        table = pd.DataFrame({"x": 1, "y": 2}, index=["a", "s1"])
+        table = qiime2.Artifact.import_data("FeatureTable[Frequency]", table)
+        metadata = qiime2.Metadata.load(get_data_path("test_metadata.txt"))
+
+        gradient_clustering(table, metadata.get_column("x"),
+                            ignore_missing_samples=True)
+
     def test_assign_ids(self):
         from qiime2.plugins.gneiss.methods import assign_ids
         tree_f = get_data_path("tree.qza")

--- a/q2_gneiss/cluster/tests/test_cluster.py
+++ b/q2_gneiss/cluster/tests/test_cluster.py
@@ -98,6 +98,8 @@ class TestClusteringPlugin(unittest.TestCase):
 
         gradient_clustering(table, metadata.get_column("x"),
                             ignore_missing_samples=True)
+        # Checkpoint assertion
+        self.assertTrue(True)
 
     def test_assign_ids(self):
         from qiime2.plugins.gneiss.methods import assign_ids


### PR DESCRIPTION
Closes #25 The only relevant non-deprecated method I found for this was `gradient_clustering`, it now defaults to excepting if there are any samples present in the table that are not in the metadata and has an `ignore_missing_samples` parameter to intentionally bypass this check.